### PR TITLE
Add build aspect

### DIFF
--- a/lib/analysis/ProjectAnalysisResult.ts
+++ b/lib/analysis/ProjectAnalysisResult.ts
@@ -46,5 +46,5 @@ export interface ProjectAnalysisResult {
 
 export function isProjectAnalysisResult(r: any): r is ProjectAnalysisResult {
     const maybe = r as ProjectAnalysisResult;
-    return !!maybe.repoRef && !!maybe.timestamp;
+    return !!maybe.repoRef && !!maybe.analysis;
 }

--- a/lib/analysis/offline/persist/PostgresProjectAnalysisResultStore.ts
+++ b/lib/analysis/offline/persist/PostgresProjectAnalysisResultStore.ts
@@ -537,7 +537,7 @@ FROM repo_snapshots rs
     RIGHT JOIN repo_fingerprints rf ON rf.repo_snapshot_id = rs.id
     INNER JOIN fingerprints f ON rf.fingerprint_id = f.id
 WHERE rs.workspace_id ${workspaceId === "*" ? "<>" : "="} $1
-    AND ${type ? "type = $2" : "true"} AND ${name ? "f.name = $3" : "true"}`;
+    AND ${type ? "f.feature_name = $2" : "true"} AND ${name ? "f.name = $3" : "true"}`;
     return doWithClient(sql, clientFactory, async client => {
         const params = [workspaceId];
         if (!!type) {

--- a/lib/analysis/offline/persist/PostgresProjectAnalysisResultStore.ts
+++ b/lib/analysis/offline/persist/PostgresProjectAnalysisResultStore.ts
@@ -454,7 +454,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, current_timestamp)`;
             }, {
                 insertedCount: 0,
                 failures: analyzed.fingerprints
-                    .map(failedFingerprint => ({ failedFingerprint, error: undefined }))
+                    .map(failedFingerprint => ({ failedFingerprint, error: undefined })),
             });
     }
 

--- a/lib/analysis/offline/persist/PostgresProjectAnalysisResultStore.ts
+++ b/lib/analysis/offline/persist/PostgresProjectAnalysisResultStore.ts
@@ -54,7 +54,8 @@ import {
 } from "./pgUtils";
 import {
     combinePersistResults,
-    emptyPersistResult, FingerprintInsertionResult,
+    emptyPersistResult,
+    FingerprintInsertionResult,
     FingerprintKind,
     FingerprintUsage,
     PersistResult,

--- a/lib/analysis/offline/persist/ProjectAnalysisResultStore.ts
+++ b/lib/analysis/offline/persist/ProjectAnalysisResultStore.ts
@@ -23,7 +23,7 @@ import {
     PersistenceResult,
     SpiderFailure,
 } from "../spider/Spider";
-import { ClientFactory } from "./pgUtils";
+import { Analyzed, HasFingerprints } from "../../../aspect/AspectRegistry";
 
 export interface PersistResult {
     attemptedCount: number;
@@ -70,6 +70,11 @@ export interface TreeQuery {
     byName: boolean;
 
     includeWithout: boolean;
+}
+
+export interface FingerprintInsertionResult {
+    insertedCount: number;
+    failures: Array<{ failedFingerprint: FP; error: Error }>;
 }
 
 /**
@@ -129,6 +134,11 @@ export interface ProjectAnalysisResultStore {
     loadById(id: string): Promise<ProjectAnalysisResult | undefined>;
 
     persist(repos: ProjectAnalysisResult | AsyncIterable<ProjectAnalysisResult> | ProjectAnalysisResult[]): Promise<PersistResult>;
+
+    /**
+     * Persist fingerprints for this snapshot id, which must already exist.
+     */
+    persistAdditionalFingerprints(analyzed: Analyzed): Promise<FingerprintInsertionResult>;
 
     /**
      * Return distinct fingerprint type/name combinations in this workspace

--- a/lib/analysis/offline/persist/ProjectAnalysisResultStore.ts
+++ b/lib/analysis/offline/persist/ProjectAnalysisResultStore.ts
@@ -16,7 +16,10 @@
 
 import { RepoRef } from "@atomist/automation-client";
 import { FP } from "@atomist/sdm-pack-fingerprints";
-import { Analyzed, HasFingerprints } from "../../../aspect/AspectRegistry";
+import {
+    Analyzed,
+    HasFingerprints,
+} from "../../../aspect/AspectRegistry";
 import { PlantedTree } from "../../../tree/sunburst";
 import { ProjectAnalysisResult } from "../../ProjectAnalysisResult";
 import { CohortAnalysis } from "../spider/analytics";

--- a/lib/analysis/offline/persist/ProjectAnalysisResultStore.ts
+++ b/lib/analysis/offline/persist/ProjectAnalysisResultStore.ts
@@ -16,6 +16,7 @@
 
 import { RepoRef } from "@atomist/automation-client";
 import { FP } from "@atomist/sdm-pack-fingerprints";
+import { Analyzed, HasFingerprints } from "../../../aspect/AspectRegistry";
 import { PlantedTree } from "../../../tree/sunburst";
 import { ProjectAnalysisResult } from "../../ProjectAnalysisResult";
 import { CohortAnalysis } from "../spider/analytics";
@@ -23,7 +24,6 @@ import {
     PersistenceResult,
     SpiderFailure,
 } from "../spider/Spider";
-import { Analyzed, HasFingerprints } from "../../../aspect/AspectRegistry";
 
 export interface PersistResult {
     attemptedCount: number;

--- a/lib/analysis/offline/spider/SpiderAnalyzer.ts
+++ b/lib/analysis/offline/spider/SpiderAnalyzer.ts
@@ -20,12 +20,14 @@ import {
     Project, ProjectOperationCredentials,
     RemoteRepoRef,
 } from "@atomist/automation-client";
+import { PreferenceStore, PushImpactListenerInvocation } from "@atomist/sdm";
 import { toArray } from "@atomist/sdm-core/lib/util/misc/array";
 import {
     Aspect,
     FP,
     VirtualProjectFinder,
 } from "@atomist/sdm-pack-fingerprints";
+import { Error } from "tslint/lib/error";
 import {
     Analyzed,
 } from "../../../aspect/AspectRegistry";
@@ -34,8 +36,6 @@ import {
     Analyzer,
     TimeRecorder,
 } from "./Spider";
-import { PreferenceStore, PushImpactListenerInvocation } from "@atomist/sdm";
-import { Error } from "tslint/lib/error";
 
 /**
  * Analyzer implementation that captures timings that are useful during

--- a/lib/analysis/offline/spider/SpiderAnalyzer.ts
+++ b/lib/analysis/offline/spider/SpiderAnalyzer.ts
@@ -90,7 +90,8 @@ async function extractAtomicAspects(p: Project,
 async function extractify(aspect: Aspect, p: Project, timeRecorder: TimeRecorder): Promise<FP[]> {
     try {
         const timed = await time(
-            async () => aspect.extract(p));
+            // TODO fake up push invocation
+            async () => aspect.extract(p, undefined));
         addTiming(aspect.name, timed.millis, timeRecorder);
         const result = !!timed.result ? toArray(timed.result) : [];
         return result;

--- a/lib/analysis/offline/spider/SpiderAnalyzer.ts
+++ b/lib/analysis/offline/spider/SpiderAnalyzer.ts
@@ -15,12 +15,17 @@
  */
 
 import {
-    GitProject, HandlerContext,
+    GitProject,
+    HandlerContext,
     logger,
-    Project, ProjectOperationCredentials,
+    Project,
+    ProjectOperationCredentials,
     RemoteRepoRef,
 } from "@atomist/automation-client";
-import { PreferenceStore, PushImpactListenerInvocation } from "@atomist/sdm";
+import {
+    PreferenceStore,
+    PushImpactListenerInvocation,
+} from "@atomist/sdm";
 import { toArray } from "@atomist/sdm-core/lib/util/misc/array";
 import {
     Aspect,

--- a/lib/analysis/offline/spider/SpiderAnalyzer.ts
+++ b/lib/analysis/offline/spider/SpiderAnalyzer.ts
@@ -15,8 +15,9 @@
  */
 
 import {
+    GitProject, HandlerContext,
     logger,
-    Project,
+    Project, ProjectOperationCredentials,
     RemoteRepoRef,
 } from "@atomist/automation-client";
 import { toArray } from "@atomist/sdm-core/lib/util/misc/array";
@@ -33,7 +34,13 @@ import {
     Analyzer,
     TimeRecorder,
 } from "./Spider";
+import { PreferenceStore, PushImpactListenerInvocation } from "@atomist/sdm";
+import { Error } from "tslint/lib/error";
 
+/**
+ * Analyzer implementation that captures timings that are useful during
+ * development, but don't need to be captured during regular execution.
+ */
 export class SpiderAnalyzer implements Analyzer {
 
     public readonly timings: TimeRecorder = {};
@@ -41,17 +48,12 @@ export class SpiderAnalyzer implements Analyzer {
     public async analyze(p: Project): Promise<Analyzed> {
         const fingerprints: FP[] = [];
 
-        const regularAspects: Aspect[] = this.aspects.filter(a => !!(a as any).extract) as any;
-        const atomicAspects = this.aspects.filter(aspect => !!aspect.consolidate);
-
         if (this.virtualProjectFinder) {
             // Seed the virtual project finder if we have one
             await this.virtualProjectFinder.findVirtualProjectInfo(p);
         }
-        await extractRegularAspects(p, regularAspects,
-            fingerprints, this.timings);
-
-        await extractAtomicAspects(p, atomicAspects, fingerprints);
+        await extractRegularAspects(p, this.aspects, fingerprints, this.timings);
+        await extractAtomicAspects(p, this.aspects.filter(aspect => !!aspect.consolidate), fingerprints);
 
         return {
             id: p.id as RemoteRepoRef,
@@ -70,8 +72,7 @@ async function extractRegularAspects(p: Project,
                                      fingerprints: FP[],
                                      timings: TimeRecorder): Promise<void> {
     await Promise.all(aspects
-    // TODO why is this cast needed?
-        .map(aspect => extractify(aspect as any, p, timings)
+        .map(aspect => extractify(aspect, p, timings)
             .then(fps =>
                 fingerprints.push(...fps),
             )));
@@ -88,10 +89,27 @@ async function extractAtomicAspects(p: Project,
 }
 
 async function extractify(aspect: Aspect, p: Project, timeRecorder: TimeRecorder): Promise<FP[]> {
+    const minimalPushImpactListenerInvocation: PushImpactListenerInvocation = {
+        id: p.id as any,
+        get context(): HandlerContext { throw new Error("Unsupported"); },
+        commit: {
+            sha: p.id.sha,
+        },
+        project: p as GitProject,
+        push: {
+            repo: undefined,
+            branch: "master",
+        },
+        addressChannels: async () => {},
+        get filesChanged(): string[] { throw new Error("Unsupported"); },
+        get credentials(): ProjectOperationCredentials { throw new Error("Unsupported"); },
+        impactedSubProject: p,
+        get preferences(): PreferenceStore { throw new Error("Unsupported"); },
+        configuration: {},
+    };
+
     try {
-        const timed = await time(
-            // TODO fake up push invocation
-            async () => aspect.extract(p, undefined));
+        const timed = await time(async () => aspect.extract(p, minimalPushImpactListenerInvocation));
         addTiming(aspect.name, timed.millis, timeRecorder);
         const result = !!timed.result ? toArray(timed.result) : [];
         return result;

--- a/lib/analysis/offline/spider/analytics.ts
+++ b/lib/analysis/offline/spider/analytics.ts
@@ -45,6 +45,9 @@ export async function computeAnalyticsForFingerprintKind(persister: ProjectAnaly
                                                          type: string,
                                                          name: string): Promise<void> {
     const fingerprints = await persister.fingerprintsInWorkspace(workspaceId, false, type, name);
+    if (fingerprints.length === 0) {
+        return;
+    }
     const cohortAnalysis = analyzeCohort(fingerprints);
     await persister.persistAnalytics([{ workspaceId, kind: { type, name }, cohortAnalysis }]);
 }

--- a/lib/aspect/compose/conditionalize.ts
+++ b/lib/aspect/compose/conditionalize.ts
@@ -35,10 +35,10 @@ export function conditionalize(aspect: Aspect,
         displayName: details.displayName || aspect.displayName,
         toDisplayableFingerprintName: details.toDisplayableFingerprintName || aspect.toDisplayableFingerprintName,
         toDisplayableFingerprint: details.toDisplayableFingerprint || aspect.toDisplayableFingerprint,
-        extract: async p => {
+        extract: async (p, pli) => {
             const testResult = await test(p);
             if (testResult) {
-                const rawFingerprints = toArray(await aspect.extract(p));
+                const rawFingerprints = toArray(await aspect.extract(p, pli));
                 return rawFingerprints.map(raw => {
                     const merged = {
                         ...raw,

--- a/lib/machine/aspectSupport.ts
+++ b/lib/machine/aspectSupport.ts
@@ -82,7 +82,8 @@ export const DefaultScoreWeightings: ScoreWeightings = {
 export interface AspectSupportOptions {
 
     /**
-     * Aspects that drive behavior of this SDM
+     * Aspects that cause this SDM to calculate fingerprints from projects
+     * and delivery events.
      */
     aspects: Aspect | Aspect[];
 

--- a/lib/machine/aspectSupport.ts
+++ b/lib/machine/aspectSupport.ts
@@ -27,12 +27,11 @@ import {
 } from "@atomist/sdm";
 import { isInLocalMode } from "@atomist/sdm-core";
 import { toArray } from "@atomist/sdm-core/lib/util/misc/array";
-import { Build } from "@atomist/sdm-pack-build";
 import {
     Aspect,
     cachingVirtualProjectFinder,
     fileNamesVirtualProjectFinder,
-    fingerprintSupport,
+    fingerprintSupport, PublishFingerprints,
     VirtualProjectFinder,
 } from "@atomist/sdm-pack-fingerprints";
 import {
@@ -93,7 +92,11 @@ export interface AspectSupportOptions extends Partial<DeliveryGoals> {
 
     undesirableUsageChecker?: UndesirableUsageChecker;
 
+<<<<<<< HEAD
     exposeWeb?: boolean;
+=======
+    publishFingerprints?: PublishFingerprints;
+>>>>>>> Upgrade fingerprints pack
 }
 
 export function aspectSupport(options: AspectSupportOptions): ExtensionPack {
@@ -116,11 +119,12 @@ export function aspectSupport(options: AspectSupportOptions): ExtensionPack {
                 sdm.addExtensionPacks(fingerprintSupport({
                     pushImpactGoal: options.pushImpactGoal,
                     aspects: options.aspects,
+                    publishFingerprints: options.publishFingerprints,
                 }));
                 if (!!options.build) {
                     toArray(options.aspects)
                         .filter(isDeliveryAspect)
-                        .forEach(da => da.register(sdm, options));
+                        .forEach(da => da.register(sdm, options, options.publishFingerprints));
                 }
             }
 

--- a/lib/machine/aspectSupport.ts
+++ b/lib/machine/aspectSupport.ts
@@ -35,7 +35,10 @@ import {
     fingerprintSupport,
     VirtualProjectFinder,
 } from "@atomist/sdm-pack-fingerprints";
-import { DeliveryGoals, isDeliveryAspect } from "../../test/aspect/delivery/DeliveryAspect";
+import {
+    DeliveryGoals,
+    isDeliveryAspect,
+} from "../../test/aspect/delivery/DeliveryAspect";
 import { ClientFactory } from "../analysis/offline/persist/pgUtils";
 import {
     analyzeGitHubByQueryCommandRegistration,

--- a/lib/machine/aspectSupport.ts
+++ b/lib/machine/aspectSupport.ts
@@ -27,6 +27,7 @@ import {
 } from "@atomist/sdm";
 import { isInLocalMode } from "@atomist/sdm-core";
 import { toArray } from "@atomist/sdm-core/lib/util/misc/array";
+import { Build } from "@atomist/sdm-pack-build";
 import {
     Aspect,
     cachingVirtualProjectFinder,
@@ -34,6 +35,7 @@ import {
     fingerprintSupport,
     VirtualProjectFinder,
 } from "@atomist/sdm-pack-fingerprints";
+import { DeliveryGoals, isDeliveryAspect } from "../../test/aspect/delivery/DeliveryAspect";
 import { ClientFactory } from "../analysis/offline/persist/pgUtils";
 import {
     analyzeGitHubByQueryCommandRegistration,
@@ -55,8 +57,6 @@ import {
     createAnalyzer,
     sdmConfigClientFactory,
 } from "./machine";
-import { Build } from "@atomist/sdm-pack-build";
-import { DeliveryGoals, isDeliveryAspect } from "../../test/aspect/delivery/DeliveryAspect";
 
 /**
  * Consider directories containing any of these files to be virtual projects

--- a/lib/machine/aspectSupport.ts
+++ b/lib/machine/aspectSupport.ts
@@ -31,7 +31,8 @@ import {
     Aspect,
     cachingVirtualProjectFinder,
     fileNamesVirtualProjectFinder,
-    fingerprintSupport, PublishFingerprints,
+    fingerprintSupport,
+    PublishFingerprints,
     VirtualProjectFinder,
 } from "@atomist/sdm-pack-fingerprints";
 import {

--- a/lib/machine/machine.ts
+++ b/lib/machine/machine.ts
@@ -18,6 +18,7 @@ import {
     Configuration,
 } from "@atomist/automation-client";
 import {
+    makeVirtualProjectAware,
     VirtualProjectFinder,
 } from "@atomist/sdm-pack-fingerprints";
 import { Aspect } from "@atomist/sdm-pack-fingerprints/lib/machine/Aspect";
@@ -32,7 +33,8 @@ import { IdealStore } from "../aspect/IdealStore";
 import { ProblemStore } from "../aspect/ProblemStore";
 
 export function createAnalyzer(aspects: Aspect[], virtualProjectFinder: VirtualProjectFinder): Analyzer {
-    return new SpiderAnalyzer(aspects, virtualProjectFinder);
+    const configuredAspects = aspects.map(aspect => makeVirtualProjectAware(aspect, virtualProjectFinder));
+    return new SpiderAnalyzer(configuredAspects, virtualProjectFinder);
 }
 
 const PoolHolder: { pool: Pool } = { pool: undefined };

--- a/lib/routes/web-app/overviewPage.ts
+++ b/lib/routes/web-app/overviewPage.ts
@@ -55,9 +55,10 @@ export function exposeOverviewPage(express: Express,
 
             const ideals = await aspectRegistry.idealStore.loadIdeals(workspaceId);
 
-            const aspectsEligibleForDisplay = aspectRegistry.aspects.filter(a => !!a.displayName)
+            const aspectsEligibleForDisplay = aspectRegistry.aspects
+                .filter(a => !!a.displayName)
                 .filter(a => fingerprintUsage.some(fu => fu.type === a.name));
-            const importantAspects: AspectFingerprintsForDisplay[] = _.sortBy(aspectsEligibleForDisplay, a => a.displayName)
+            const foundAspects: AspectFingerprintsForDisplay[] = _.sortBy(aspectsEligibleForDisplay, a => a.displayName)
                 .map(aspect => {
                     const fingerprintsForThisAspect = fingerprintUsage.filter(fu => fu.type === aspect.name);
                     return {
@@ -75,7 +76,7 @@ export function exposeOverviewPage(express: Express,
             res.send(renderStaticReactNode(
                 Overview({
                     projectsAnalyzed: repos.length,
-                    foundAspects: importantAspects,
+                    foundAspects,
                     unfoundAspects,
                     repos: repos.map(r => ({
                         id: r.id,

--- a/package-lock.json
+++ b/package-lock.json
@@ -458,9 +458,9 @@
       }
     },
     "@atomist/sdm-pack-fingerprints": {
-      "version": "5.0.0-master.20190822232250",
-      "resolved": "https://registry.npmjs.org/@atomist/sdm-pack-fingerprints/-/sdm-pack-fingerprints-5.0.0-master.20190822232250.tgz",
-      "integrity": "sha512-QTzcO3DLT7IOdDh1fZ6DHlhcUzt7rv36KB45JAehcXZ+kkGsDJwGaB0M1zEMJmnTpS6vR5bv+EGKEX1vF3ildw==",
+      "version": "5.0.0-set-publish.20190823162648",
+      "resolved": "https://registry.npmjs.org/@atomist/sdm-pack-fingerprints/-/sdm-pack-fingerprints-5.0.0-set-publish.20190823162648.tgz",
+      "integrity": "sha512-kccutOLIaxavyZUzCajyYDr3Sy8oWMSnG9YgAqvwCM2FiafCG4BqbLm8HUVjG0WobLo+1O1iWjR2KColA44SAQ==",
       "dev": true,
       "requires": {
         "@atomist/clj-editors": "0.8.2-master.20190816115246",

--- a/package-lock.json
+++ b/package-lock.json
@@ -458,9 +458,9 @@
       }
     },
     "@atomist/sdm-pack-fingerprints": {
-      "version": "5.0.0-set-publish.20190823162648",
-      "resolved": "https://registry.npmjs.org/@atomist/sdm-pack-fingerprints/-/sdm-pack-fingerprints-5.0.0-set-publish.20190823162648.tgz",
-      "integrity": "sha512-kccutOLIaxavyZUzCajyYDr3Sy8oWMSnG9YgAqvwCM2FiafCG4BqbLm8HUVjG0WobLo+1O1iWjR2KColA44SAQ==",
+      "version": "5.0.0-master.20190825000414",
+      "resolved": "https://registry.npmjs.org/@atomist/sdm-pack-fingerprints/-/sdm-pack-fingerprints-5.0.0-master.20190825000414.tgz",
+      "integrity": "sha512-YyRJxG/LOfC9RVursfWWu4YmAQdVvq4i4YKqpoGJcjPwXtzW6Jrgo2MjKmmXRC4S+SpMptAnghZM7VXih6Ysow==",
       "dev": true,
       "requires": {
         "@atomist/clj-editors": "0.8.2-master.20190816115246",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@atomist/sdm-pack-build": "^1.0.5",
     "@atomist/sdm-pack-clojure": "^2.0.0",
     "@atomist/sdm-pack-docker": "2.0.3-master.20190821110014",
-    "@atomist/sdm-pack-fingerprints": "^5.0.0-set-publish.20190823162648",
+    "@atomist/sdm-pack-fingerprints": "^5.0.0-master.20190825000414",
     "@atomist/sdm-pack-node": "^1.1.1",
     "@atomist/sdm-pack-sloc": "1.0.3-master.20190502175705",
     "@atomist/sdm-pack-spring": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@atomist/sdm-pack-build": "^1.0.5",
     "@atomist/sdm-pack-clojure": "^2.0.0",
     "@atomist/sdm-pack-docker": "2.0.3-master.20190821110014",
-    "@atomist/sdm-pack-fingerprints": "^5.0.0-master.20190822232250",
+    "@atomist/sdm-pack-fingerprints": "^5.0.0-set-publish.20190823162648",
     "@atomist/sdm-pack-node": "^1.1.1",
     "@atomist/sdm-pack-sloc": "1.0.3-master.20190502175705",
     "@atomist/sdm-pack-spring": "^2.0.0",

--- a/test/aspect/codeOfConduct.test.ts
+++ b/test/aspect/codeOfConduct.test.ts
@@ -29,13 +29,13 @@ describe("codeOfConduct", () => {
 
     it("should find no code of conduct", async () => {
         const p = InMemoryProject.of();
-        const s = await CodeOfConduct.extract(p) as FP<CodeOfConductData>;
+        const s = await CodeOfConduct.extract(p, undefined) as FP<CodeOfConductData>;
         assert(!s);
     });
 
     it("should find test code of conduct", async () => {
         const p = InMemoryProject.of({ path: "CODE_OF_CONDUCT.md", content: testCoC });
-        const s = await CodeOfConduct.extract(p) as FP<CodeOfConductData>;
+        const s = await CodeOfConduct.extract(p, undefined) as FP<CodeOfConductData>;
         assert(!!s);
         assert.strictEqual(s.data.content, testCoC);
         assert.strictEqual(s.data.title, "The Benign Code of Conduct");
@@ -43,7 +43,7 @@ describe("codeOfConduct", () => {
 
     it("should do its best with code of conduct without title", async () => {
         const p = InMemoryProject.of({ path: "CODE_OF_CONDUCT.md", content: "meaningless" });
-        const s = await CodeOfConduct.extract(p) as FP<CodeOfConductData>;
+        const s = await CodeOfConduct.extract(p, undefined) as FP<CodeOfConductData>;
         assert(!!s);
         assert.strictEqual(s.data.content, "meaningless");
         assert(!s.data.title);

--- a/test/aspect/delivery/BuildAspect.ts
+++ b/test/aspect/delivery/BuildAspect.ts
@@ -42,6 +42,7 @@ export function buildOutcomeAspect<DATA>(opts: Omit<Aspect, "extract" | "consoli
     return {
         ...opts,
         extract: async () => [],
+        canRegister: (sdm, goals) => !!goals.build,
         register: (sdm, goals, publisher) => {
             if (!goals.build) {
                 throw new Error("No build goal supplied. Cannot register a build aspect");

--- a/test/aspect/delivery/BuildAspect.ts
+++ b/test/aspect/delivery/BuildAspect.ts
@@ -15,13 +15,20 @@
  */
 
 import { logger } from "@atomist/automation-client";
-import { BuildListener, BuildListenerInvocation, BuildStatus } from "@atomist/sdm";
+import {
+    BuildListener,
+    BuildListenerInvocation,
+    BuildStatus,
+} from "@atomist/sdm";
 import { toArray } from "@atomist/sdm-core/lib/util/misc/array";
 import { Build } from "@atomist/sdm-pack-build";
 import { Aspect, FP, sha256 } from "@atomist/sdm-pack-fingerprints";
 import { Error } from "tslint/lib/error";
 import { Omit } from "../../../lib/util/omit";
-import { DeliveryAspect, FingerprintPublisher } from "./DeliveryAspect";
+import {
+    DeliveryAspect,
+    FingerprintPublisher,
+} from "./DeliveryAspect";
 
 export type BuildAspect<DATA = any> = DeliveryAspect<{ build: Build }, DATA>;
 

--- a/test/aspect/delivery/BuildAspect.ts
+++ b/test/aspect/delivery/BuildAspect.ts
@@ -18,7 +18,7 @@ import { logger } from "@atomist/automation-client";
 import {
     BuildListener,
     BuildListenerInvocation,
-    BuildStatus,
+    BuildStatus, PushImpactListenerInvocation, PushListenerInvocation,
 } from "@atomist/sdm";
 import { toArray } from "@atomist/sdm-core/lib/util/misc/array";
 import { Build } from "@atomist/sdm-pack-build";
@@ -98,7 +98,17 @@ function buildListener(fingerprintFinder: FindFingerprintsInBuild, publisher: Pu
     return async bi => {
         if (buildCompletions.includes(bi.build.status)) {
             const fps = await fingerprintFinder(bi);
-            return publisher(bi, toArray(fps));
+            const pili: PushImpactListenerInvocation = {
+                ...bi,
+                // TODO replace by throwing error
+                project: undefined,
+                ...bi.build,
+                impactedSubProject: undefined,
+                filesChanged: undefined,
+                commit: bi.build.commit,
+                push: bi.build.push,
+            };
+            return publisher(pili, toArray(fps), {});
         }
         return false;
     };

--- a/test/aspect/delivery/BuildAspect.ts
+++ b/test/aspect/delivery/BuildAspect.ts
@@ -29,9 +29,9 @@ import {
     PublishFingerprints,
     sha256,
 } from "@atomist/sdm-pack-fingerprints";
+import { bandFor, Default } from "../../../lib/util/bands";
 import { Omit } from "../../../lib/util/omit";
 import { DeliveryAspect } from "./DeliveryAspect";
-import { bandFor, Default } from "../../../lib/util/bands";
 
 export type BuildAspect<DATA = any> = DeliveryAspect<{ build: Build }, DATA>;
 

--- a/test/aspect/delivery/BuildAspect.ts
+++ b/test/aspect/delivery/BuildAspect.ts
@@ -16,11 +16,20 @@
 
 import { logger } from "@atomist/automation-client";
 import { Build } from "@atomist/sdm-pack-build";
-import { Aspect, sha256, } from "@atomist/sdm-pack-fingerprints";
-import { bandFor, Default, } from "../../../lib/util/bands";
+import {
+    Aspect,
+    sha256,
+} from "@atomist/sdm-pack-fingerprints";
+import {
+    bandFor,
+    Default,
+} from "../../../lib/util/bands";
 import { Omit } from "../../../lib/util/omit";
 import { DeliveryAspect } from "./DeliveryAspect";
-import { FindFingerprintsFromGoalExecution, goalExecutionFingerprinter } from "./support/goalListener";
+import {
+    FindFingerprintsFromGoalExecution,
+    goalExecutionFingerprinter,
+} from "./support/goalListener";
 
 export type BuildAspect<DATA = any> = DeliveryAspect<{ build: Build }, DATA>;
 
@@ -87,4 +96,3 @@ export function buildTimeAspect(opts: Omit<Aspect, "name" | "displayName" | "ext
         },
     });
 }
-

--- a/test/aspect/delivery/BuildAspect.ts
+++ b/test/aspect/delivery/BuildAspect.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { BuildListener, BuildListenerInvocation, BuildStatus, } from "@atomist/sdm";
-import { DeliveryAspect, FingerprintPublisher } from "./DeliveryAspect";
-import { Build } from "@atomist/sdm-pack-build";
-import { Omit } from "../../../lib/util/omit";
-import { Aspect, FP, sha256 } from "@atomist/sdm-pack-fingerprints";
 import { logger } from "@atomist/automation-client";
-import { Error } from "tslint/lib/error";
+import { BuildListener, BuildListenerInvocation, BuildStatus } from "@atomist/sdm";
 import { toArray } from "@atomist/sdm-core/lib/util/misc/array";
+import { Build } from "@atomist/sdm-pack-build";
+import { Aspect, FP, sha256 } from "@atomist/sdm-pack-fingerprints";
+import { Error } from "tslint/lib/error";
+import { Omit } from "../../../lib/util/omit";
+import { DeliveryAspect, FingerprintPublisher } from "./DeliveryAspect";
 
 export type BuildAspect<DATA = any> = DeliveryAspect<{ build: Build }, DATA>;
 
@@ -56,8 +56,8 @@ export function buildOutcomeAspect<DATA>(opts: Omit<Aspect, "extract" | "consoli
             basicStatsPath: "millis",
             defaultStatStatus: {
                 entropy: false,
-            }
-        }
+            },
+        },
     };
 }
 
@@ -73,7 +73,7 @@ export function buildTimeAspect(opts: Omit<Aspect, "name" | "displayName" | "ext
         displayName: "Build time",
         fingerprintFinder: async bi => {
             // TODO fix me
-            const millis = -1;// bi.build.timestamp - bi.build.startedAt;
+            const millis = -1; // bi.build.timestamp - bi.build.startedAt;
             const data = {millis };
             return {
                 name: BuildTimeType,

--- a/test/aspect/delivery/BuildAspect.ts
+++ b/test/aspect/delivery/BuildAspect.ts
@@ -37,7 +37,7 @@ export type BuildAspect<DATA = any> = DeliveryAspect<{ build: Build }, DATA>;
 export type FindFingerprintsInBuild = (gei: GoalExecutionListenerInvocation) => Promise<FP[] | FP>;
 
 export interface BuildTimeData {
-    millis: number;
+    elapsedMillis: number;
 }
 
 /**
@@ -79,7 +79,7 @@ export function buildTimeAspect(opts: Omit<Aspect, "name" | "displayName" | "ext
         displayName: "Build time",
         fingerprintFinder: async gei => {
             const elapsedMillis = Date.now() - gei.goalEvent.ts;
-            const data = { millis: elapsedMillis };
+            const data = { elapsedMillis };
             return {
                 name: BuildTimeType,
                 type: BuildTimeType,
@@ -87,6 +87,8 @@ export function buildTimeAspect(opts: Omit<Aspect, "name" | "displayName" | "ext
                 sha: sha256(JSON.stringify(data)),
             };
         },
+        toDisplayableFingerprintName: () => "Build time",
+        toDisplayableFingerprint: fp => `${fp.data.elapsedMillis}ms`,
     });
 }
 

--- a/test/aspect/delivery/BuildAspect.ts
+++ b/test/aspect/delivery/BuildAspect.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BuildListener, BuildListenerInvocation, BuildStatus, } from "@atomist/sdm";
+import { DeliveryAspect, FingerprintPublisher } from "./DeliveryAspect";
+import { Build } from "@atomist/sdm-pack-build";
+import { Omit } from "../../../lib/util/omit";
+import { Aspect, FP, sha256 } from "@atomist/sdm-pack-fingerprints";
+import { logger } from "@atomist/automation-client";
+import { Error } from "tslint/lib/error";
+import { toArray } from "@atomist/sdm-core/lib/util/misc/array";
+
+export type BuildAspect<DATA = any> = DeliveryAspect<{ build: Build }, DATA>;
+
+const buildCompletions = [BuildStatus.broken, BuildStatus.error, BuildStatus.failed, BuildStatus.passed];
+
+export type FindFingerprintsInBuild = (completedBuild: BuildListenerInvocation) => Promise<FP[] | FP>;
+
+export interface BuildTimeData {
+    millis: number;
+}
+
+/**
+ * Create an SDM BuildListener from BuildAspect
+ */
+export function buildOutcomeAspect<DATA>(opts: Omit<Aspect, "extract" | "consolidate"> & {
+    build?: Build,
+    publisher: FingerprintPublisher,
+    fingerprintFinder: FindFingerprintsInBuild,
+}): BuildAspect<DATA> {
+    // TODO default publisher
+    return {
+        ...opts,
+        extract: async () => [],
+        register: (sdm, goals) => {
+            if (!goals.build) {
+                throw new Error("No build goal supplied. Cannot register a build aspect");
+            }
+            logger.info("Registering build aspect %s", opts.name);
+            return goals.build.withListener(buildListener(opts.fingerprintFinder, opts.publisher));
+        },
+        stats: {
+            basicStatsPath: "millis",
+            defaultStatStatus: {
+                entropy: false,
+            }
+        }
+    };
+}
+
+export const BuildTimeType = "build-time";
+
+export function buildTimeAspect(opts: Omit<Aspect, "name" | "displayName" | "extract" | "consolidate"> & {
+    build?: Build,
+    publisher: FingerprintPublisher,
+}): BuildAspect<BuildTimeData> {
+    return buildOutcomeAspect({
+        ...opts,
+        name: "build-time",
+        displayName: "Build time",
+        fingerprintFinder: async bi => {
+            // TODO fix me
+            const millis = -1;// bi.build.timestamp - bi.build.startedAt;
+            const data = {millis };
+            return {
+                name: BuildTimeType,
+                type: BuildTimeType,
+                data,
+                sha: sha256(JSON.stringify(data)),
+            };
+        },
+    });
+}
+
+function buildListener(fingerprintFinder: FindFingerprintsInBuild, publisher: FingerprintPublisher): BuildListener {
+    return async bi => {
+        if (buildCompletions.includes(bi.build.status)) {
+            const fps = await fingerprintFinder(bi);
+            return publisher(bi, toArray(fps));
+        }
+        return false;
+    };
+}

--- a/test/aspect/delivery/BuildAspect.ts
+++ b/test/aspect/delivery/BuildAspect.ts
@@ -18,7 +18,9 @@ import { logger } from "@atomist/automation-client";
 import {
     BuildListener,
     BuildListenerInvocation,
-    BuildStatus, PushImpactListenerInvocation, PushListenerInvocation,
+    BuildStatus,
+    PushImpactListenerInvocation,
+    PushListenerInvocation,
 } from "@atomist/sdm";
 import { toArray } from "@atomist/sdm-core/lib/util/misc/array";
 import { Build } from "@atomist/sdm-pack-build";

--- a/test/aspect/delivery/DeliveryAspect.ts
+++ b/test/aspect/delivery/DeliveryAspect.ts
@@ -15,14 +15,18 @@
  */
 
 import {
+    GoalExecutionListenerInvocation,
     SoftwareDeliveryMachine,
 } from "@atomist/sdm";
 import { AllGoals } from "@atomist/sdm-core";
 import {
-    Aspect,
+    Aspect, FP,
     PublishFingerprints,
 } from "@atomist/sdm-pack-fingerprints";
 
+/**
+ * Aspect that can register to extract fingerprints from Atomist events
+ */
 export interface DeliveryAspect<GOALS extends AllGoals, DATA = any> extends Aspect<DATA> {
 
     /**

--- a/test/aspect/delivery/DeliveryAspect.ts
+++ b/test/aspect/delivery/DeliveryAspect.ts
@@ -15,13 +15,12 @@
  */
 
 import {
-    SdmContext,
     SoftwareDeliveryMachine,
 } from "@atomist/sdm";
 import { Build } from "@atomist/sdm-pack-build";
 import {
     Aspect,
-    FP,
+    FP, PublishFingerprints,
 } from "@atomist/sdm-pack-fingerprints";
 
 // TODO does this exist
@@ -29,12 +28,12 @@ export interface DeliveryGoals {
     build?: Build;
 }
 
-// TODO does this exist anywhere
-export type FingerprintPublisher = (ctx: SdmContext, fps: FP[]) => Promise<boolean>;
-
 export interface DeliveryAspect<GOALS extends DeliveryGoals, DATA = any> extends Aspect<DATA> {
 
-    register(sdm: SoftwareDeliveryMachine, deliveryGoals: GOALS): void;
+    /**
+     * Cause this to emit fingerprints
+     */
+    register(sdm: SoftwareDeliveryMachine, deliveryGoals: GOALS, publisher: PublishFingerprints): void;
 
 }
 

--- a/test/aspect/delivery/DeliveryAspect.ts
+++ b/test/aspect/delivery/DeliveryAspect.ts
@@ -20,7 +20,8 @@ import {
 import { Build } from "@atomist/sdm-pack-build";
 import {
     Aspect,
-    FP, PublishFingerprints,
+    FP,
+    PublishFingerprints,
 } from "@atomist/sdm-pack-fingerprints";
 
 // TODO does this exist

--- a/test/aspect/delivery/DeliveryAspect.ts
+++ b/test/aspect/delivery/DeliveryAspect.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Aspect, FP } from "@atomist/sdm-pack-fingerprints";
 import { SdmContext, SoftwareDeliveryMachine } from "@atomist/sdm";
 import { Build } from "@atomist/sdm-pack-build";

--- a/test/aspect/delivery/DeliveryAspect.ts
+++ b/test/aspect/delivery/DeliveryAspect.ts
@@ -14,9 +14,15 @@
  * limitations under the License.
  */
 
-import { SdmContext, SoftwareDeliveryMachine } from "@atomist/sdm";
+import {
+    SdmContext,
+    SoftwareDeliveryMachine,
+} from "@atomist/sdm";
 import { Build } from "@atomist/sdm-pack-build";
-import { Aspect, FP } from "@atomist/sdm-pack-fingerprints";
+import {
+    Aspect,
+    FP,
+} from "@atomist/sdm-pack-fingerprints";
 
 // TODO does this exist
 export interface DeliveryGoals {

--- a/test/aspect/delivery/DeliveryAspect.ts
+++ b/test/aspect/delivery/DeliveryAspect.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { Aspect, FP } from "@atomist/sdm-pack-fingerprints";
 import { SdmContext, SoftwareDeliveryMachine } from "@atomist/sdm";
 import { Build } from "@atomist/sdm-pack-build";
+import { Aspect, FP } from "@atomist/sdm-pack-fingerprints";
 
 // TODO does this exist
 export interface DeliveryGoals {
@@ -26,13 +26,11 @@ export interface DeliveryGoals {
 // TODO does this exist anywhere
 export type FingerprintPublisher = (ctx: SdmContext, fps: FP[]) => Promise<boolean>;
 
-
 export interface DeliveryAspect<GOALS extends DeliveryGoals, DATA = any> extends Aspect<DATA> {
 
     register(sdm: SoftwareDeliveryMachine, deliveryGoals: GOALS): void;
 
 }
-
 
 export function isDeliveryAspect(a: Aspect): a is DeliveryAspect<any> {
     const maybe = a as DeliveryAspect<any>;

--- a/test/aspect/delivery/DeliveryAspect.ts
+++ b/test/aspect/delivery/DeliveryAspect.ts
@@ -1,0 +1,24 @@
+import { Aspect, FP } from "@atomist/sdm-pack-fingerprints";
+import { SdmContext, SoftwareDeliveryMachine } from "@atomist/sdm";
+import { Build } from "@atomist/sdm-pack-build";
+
+// TODO does this exist
+export interface DeliveryGoals {
+    build?: Build;
+}
+
+// TODO does this exist anywhere
+export type FingerprintPublisher = (ctx: SdmContext, fps: FP[]) => Promise<boolean>;
+
+
+export interface DeliveryAspect<GOALS extends DeliveryGoals, DATA = any> extends Aspect<DATA> {
+
+    register(sdm: SoftwareDeliveryMachine, deliveryGoals: GOALS): void;
+
+}
+
+
+export function isDeliveryAspect(a: Aspect): a is DeliveryAspect<any> {
+    const maybe = a as DeliveryAspect<any>;
+    return !!maybe.register;
+}

--- a/test/aspect/delivery/DeliveryAspect.ts
+++ b/test/aspect/delivery/DeliveryAspect.ts
@@ -17,19 +17,13 @@
 import {
     SoftwareDeliveryMachine,
 } from "@atomist/sdm";
-import { Build } from "@atomist/sdm-pack-build";
+import { AllGoals } from "@atomist/sdm-core";
 import {
     Aspect,
-    FP,
     PublishFingerprints,
 } from "@atomist/sdm-pack-fingerprints";
 
-// TODO does this exist
-export interface DeliveryGoals {
-    build?: Build;
-}
-
-export interface DeliveryAspect<GOALS extends DeliveryGoals, DATA = any> extends Aspect<DATA> {
+export interface DeliveryAspect<GOALS extends AllGoals, DATA = any> extends Aspect<DATA> {
 
     /**
      * Cause this to emit fingerprints

--- a/test/aspect/delivery/DeliveryAspect.ts
+++ b/test/aspect/delivery/DeliveryAspect.ts
@@ -20,7 +20,8 @@ import {
 } from "@atomist/sdm";
 import { AllGoals } from "@atomist/sdm-core";
 import {
-    Aspect, FP,
+    Aspect,
+    FP,
     PublishFingerprints,
 } from "@atomist/sdm-pack-fingerprints";
 

--- a/test/aspect/delivery/DeliveryAspect.ts
+++ b/test/aspect/delivery/DeliveryAspect.ts
@@ -31,6 +31,11 @@ import {
 export interface DeliveryAspect<GOALS extends AllGoals, DATA = any> extends Aspect<DATA> {
 
     /**
+     * Can this delivery aspect be registered given these goals
+     */
+    canRegister(sdm: SoftwareDeliveryMachine, goals: GOALS): boolean;
+
+    /**
      * Cause this to emit fingerprints
      */
     register(sdm: SoftwareDeliveryMachine, deliveryGoals: GOALS, publisher: PublishFingerprints): void;

--- a/test/aspect/delivery/storeFingerprintsPublisher.ts
+++ b/test/aspect/delivery/storeFingerprintsPublisher.ts
@@ -19,6 +19,7 @@ import { PublishFingerprints } from "@atomist/sdm-pack-fingerprints";
 import { ProjectAnalysisResultStore } from "../../../lib/analysis/offline/persist/ProjectAnalysisResultStore";
 import { ProjectAnalysisResult } from "../../../lib/analysis/ProjectAnalysisResult";
 import { Analyzed } from "../../../lib/aspect/AspectRegistry";
+import { computeAnalyticsForFingerprintKind } from "../../../lib/analysis/offline/spider/analytics";
 
 /**
  * "Publish" fingerprints to local store
@@ -42,6 +43,12 @@ export function storeFingerprints(store: ProjectAnalysisResultStore): PublishFin
             fingerprints.length, i.context.workspaceId);
         const results = await store.persist(paResult);
         logger.info("Persistence results: %j", results);
+
+        // TODO clean this up. It's inefficient and maybe should be in a stored proc
+        for (const fp of fingerprints) {
+            await computeAnalyticsForFingerprintKind(store, i.context.workspaceId, fp.type, fp.name);
+        }
+
         return results.failed.length === 0;
     };
 }

--- a/test/aspect/delivery/storeFingerprintsPublisher.ts
+++ b/test/aspect/delivery/storeFingerprintsPublisher.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { PublishFingerprints } from "@atomist/sdm-pack-fingerprints";
 import { ProjectAnalysisResultStore } from "../../../lib/analysis/offline/persist/ProjectAnalysisResultStore";
 

--- a/test/aspect/delivery/storeFingerprintsPublisher.ts
+++ b/test/aspect/delivery/storeFingerprintsPublisher.ts
@@ -24,7 +24,7 @@ import { ProjectAnalysisResultStore } from "../../../lib/analysis/offline/persis
  */
 export function storeFingerprints(store: ProjectAnalysisResultStore): PublishFingerprints {
     return async (i, fingerprints) => {
-        return store.persist({
+        await store.persist({
             repoRef: i.id,
             // TODO do we need to set this?
             timestamp: undefined,
@@ -34,5 +34,6 @@ export function storeFingerprints(store: ProjectAnalysisResultStore): PublishFin
                 fingerprints,
             },
         });
+        return true;
     };
 }

--- a/test/aspect/delivery/storeFingerprintsPublisher.ts
+++ b/test/aspect/delivery/storeFingerprintsPublisher.ts
@@ -28,6 +28,10 @@ import { Analyzed } from "../../../lib/aspect/AspectRegistry";
  */
 export function storeFingerprints(store: ProjectAnalysisResultStore): PublishFingerprints {
     return async (i, fingerprints) => {
+        if (fingerprints.length === 0) {
+            return true;
+        }
+
         const analysis: Analyzed = {
             id: i.id,
             fingerprints,

--- a/test/aspect/delivery/storeFingerprintsPublisher.ts
+++ b/test/aspect/delivery/storeFingerprintsPublisher.ts
@@ -17,9 +17,9 @@
 import { logger } from "@atomist/automation-client";
 import { PublishFingerprints } from "@atomist/sdm-pack-fingerprints";
 import { ProjectAnalysisResultStore } from "../../../lib/analysis/offline/persist/ProjectAnalysisResultStore";
+import { computeAnalyticsForFingerprintKind } from "../../../lib/analysis/offline/spider/analytics";
 import { ProjectAnalysisResult } from "../../../lib/analysis/ProjectAnalysisResult";
 import { Analyzed } from "../../../lib/aspect/AspectRegistry";
-import { computeAnalyticsForFingerprintKind } from "../../../lib/analysis/offline/spider/analytics";
 
 /**
  * "Publish" fingerprints to local store

--- a/test/aspect/delivery/storeFingerprintsPublisher.ts
+++ b/test/aspect/delivery/storeFingerprintsPublisher.ts
@@ -35,7 +35,6 @@ export function storeFingerprints(store: ProjectAnalysisResultStore): PublishFin
         const paResult: ProjectAnalysisResult = {
             repoRef: i.id,
             workspaceId: i.context.workspaceId,
-            // TODO do we need to set this
             timestamp: undefined,
             analysis,
         };
@@ -44,7 +43,6 @@ export function storeFingerprints(store: ProjectAnalysisResultStore): PublishFin
         const results = await store.persist(paResult);
         logger.info("Persistence results: %j", results);
 
-        // TODO clean this up. It's inefficient and maybe should be in a stored proc
         for (const fp of fingerprints) {
             await computeAnalyticsForFingerprintKind(store, i.context.workspaceId, fp.type, fp.name);
         }

--- a/test/aspect/delivery/storeFingerprintsPublisher.ts
+++ b/test/aspect/delivery/storeFingerprintsPublisher.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+import { logger } from "@atomist/automation-client";
 import { PublishFingerprints } from "@atomist/sdm-pack-fingerprints";
 import { ProjectAnalysisResultStore } from "../../../lib/analysis/offline/persist/ProjectAnalysisResultStore";
-import { logger } from "@atomist/automation-client";
-import { Analyzed } from "../../../lib/aspect/AspectRegistry";
 import { ProjectAnalysisResult } from "../../../lib/analysis/ProjectAnalysisResult";
+import { Analyzed } from "../../../lib/aspect/AspectRegistry";
 
 /**
  * "Publish" fingerprints to local store

--- a/test/aspect/delivery/storeFingerprintsPublisher.ts
+++ b/test/aspect/delivery/storeFingerprintsPublisher.ts
@@ -1,0 +1,22 @@
+import { PublishFingerprints } from "@atomist/sdm-pack-fingerprints";
+import { ProjectAnalysisResultStore } from "../../../lib/analysis/offline/persist/ProjectAnalysisResultStore";
+
+/**
+ * "Publish" fingerprints to local store
+ * @param {ProjectAnalysisResultStore} store
+ * @return {PublishFingerprints}
+ */
+export function storeFingerprints(store: ProjectAnalysisResultStore): PublishFingerprints {
+    return async (i, fingerprints) => {
+        return store.persist({
+            repoRef: i.id,
+            // TODO do we need to set this?
+            timestamp: undefined,
+            workspaceId: i.context.workspaceId,
+            analysis: {
+                id: i.id,
+                fingerprints,
+            },
+        });
+    };
+}

--- a/test/aspect/delivery/support/goalListener.ts
+++ b/test/aspect/delivery/support/goalListener.ts
@@ -28,7 +28,8 @@ import {
 
 export type FindFingerprintsFromGoalExecution = (gei: GoalExecutionListenerInvocation) => Promise<FP[] | FP>;
 
-export function goalExecutionFingerprinter(fingerprintFinder: FindFingerprintsFromGoalExecution, publisher: PublishFingerprints): GoalExecutionListener {
+export function goalExecutionFingerprinter(fingerprintFinder: FindFingerprintsFromGoalExecution,
+                                           publisher: PublishFingerprints): GoalExecutionListener {
     return async gei => {
         if (gei.goalEvent.state !== SdmGoalState.in_process) {
             const fps = await fingerprintFinder(gei);

--- a/test/aspect/delivery/support/goalListener.ts
+++ b/test/aspect/delivery/support/goalListener.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {
     GoalExecutionListener,
     GoalExecutionListenerInvocation,

--- a/test/aspect/delivery/support/goalListener.ts
+++ b/test/aspect/delivery/support/goalListener.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { GitProject, Project } from "@atomist/automation-client";
+import {
+    GitProject,
+    Project,
+} from "@atomist/automation-client";
 import {
     GoalExecutionListener,
     GoalExecutionListenerInvocation,
@@ -22,7 +25,10 @@ import {
     SdmGoalState,
 } from "@atomist/sdm";
 import { toArray } from "@atomist/sdm-core/lib/util/misc/array";
-import { FP, PublishFingerprints } from "@atomist/sdm-pack-fingerprints";
+import {
+    FP,
+    PublishFingerprints,
+} from "@atomist/sdm-pack-fingerprints";
 
 export type FindFingerprintsFromGoalExecution = (gei: GoalExecutionListenerInvocation) => Promise<FP[] | FP>;
 

--- a/test/aspect/delivery/support/goalListener.ts
+++ b/test/aspect/delivery/support/goalListener.ts
@@ -15,10 +15,6 @@
  */
 
 import {
-    GitProject,
-    Project,
-} from "@atomist/automation-client";
-import {
     GoalExecutionListener,
     GoalExecutionListenerInvocation,
     PushImpactListenerInvocation,
@@ -38,9 +34,9 @@ export function goalExecutionFingerprinter(fingerprintFinder: FindFingerprintsFr
             const fps = await fingerprintFinder(gei);
             const pili: PushImpactListenerInvocation = {
                 ...gei,
-                get project(): GitProject { throw new Error("UnsupportedOperation"); },
-                get impactedSubProject(): Project { throw new Error("UnsupportedOperation"); },
-                get filesChanged(): string[] { throw new Error("UnsupportedOperation"); },
+                project: undefined,
+                impactedSubProject: undefined,
+                filesChanged: undefined,
                 commit: gei.goalEvent.push.after,
                 push: gei.goalEvent.push,
             };

--- a/test/aspect/delivery/support/goalListener.ts
+++ b/test/aspect/delivery/support/goalListener.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
+import { GitProject, Project } from "@atomist/automation-client";
 import {
     GoalExecutionListener,
     GoalExecutionListenerInvocation,
     PushImpactListenerInvocation,
-    SdmGoalState
+    SdmGoalState,
 } from "@atomist/sdm";
-import { GitProject, Project } from "@atomist/automation-client";
 import { toArray } from "@atomist/sdm-core/lib/util/misc/array";
 import { FP, PublishFingerprints } from "@atomist/sdm-pack-fingerprints";
 
@@ -32,9 +32,9 @@ export function goalExecutionFingerprinter(fingerprintFinder: FindFingerprintsFr
             const fps = await fingerprintFinder(gei);
             const pili: PushImpactListenerInvocation = {
                 ...gei,
-                get project(): GitProject { throw new Error("UnsupportedOperation");},
-                get impactedSubProject(): Project { throw new Error("UnsupportedOperation");},
-                get filesChanged(): string[] { throw new Error("UnsupportedOperation");},
+                get project(): GitProject { throw new Error("UnsupportedOperation"); },
+                get impactedSubProject(): Project { throw new Error("UnsupportedOperation"); },
+                get filesChanged(): string[] { throw new Error("UnsupportedOperation"); },
                 commit: gei.goalEvent.push.after,
                 push: gei.goalEvent.push,
             };

--- a/test/aspect/delivery/support/goalListener.ts
+++ b/test/aspect/delivery/support/goalListener.ts
@@ -1,0 +1,29 @@
+import {
+    GoalExecutionListener,
+    GoalExecutionListenerInvocation,
+    PushImpactListenerInvocation,
+    SdmGoalState
+} from "@atomist/sdm";
+import { GitProject, Project } from "@atomist/automation-client";
+import { toArray } from "@atomist/sdm-core/lib/util/misc/array";
+import { FP, PublishFingerprints } from "@atomist/sdm-pack-fingerprints";
+
+export type FindFingerprintsFromGoalExecution = (gei: GoalExecutionListenerInvocation) => Promise<FP[] | FP>;
+
+export function goalExecutionFingerprinter(fingerprintFinder: FindFingerprintsFromGoalExecution, publisher: PublishFingerprints): GoalExecutionListener {
+    return async gei => {
+        if (gei.goalEvent.state !== SdmGoalState.in_process) {
+            const fps = await fingerprintFinder(gei);
+            const pili: PushImpactListenerInvocation = {
+                ...gei,
+                get project(): GitProject { throw new Error("UnsupportedOperation");},
+                get impactedSubProject(): Project { throw new Error("UnsupportedOperation");},
+                get filesChanged(): string[] { throw new Error("UnsupportedOperation");},
+                commit: gei.goalEvent.push.after,
+                push: gei.goalEvent.push,
+            };
+            return publisher(pili, toArray(fps), {});
+        }
+        return false;
+    };
+}

--- a/test/aspect/fileMatchAspect.test.ts
+++ b/test/aspect/fileMatchAspect.test.ts
@@ -42,7 +42,7 @@ describe("fileMatchAspect", () => {
                 }),
                 path: "name",
             });
-            const r = await aspect.extract(p) as FP<FileMatchData>;
+            const r = await aspect.extract(p, undefined) as FP<FileMatchData>;
             assert(r !== undefined);
             assert.strictEqual(r.data.matches.length, 0, JSON.stringify(r));
         });
@@ -63,7 +63,7 @@ describe("fileMatchAspect", () => {
                 }),
                 path: "age",
             });
-            const r = await aspect.extract(p) as FP<FileMatchData>;
+            const r = await aspect.extract(p, undefined) as FP<FileMatchData>;
             assert(r !== undefined);
             assert.strictEqual(r.data.matches.length, 0, JSON.stringify(r));
         });
@@ -84,7 +84,7 @@ describe("fileMatchAspect", () => {
                 }),
                 path: "age",
             });
-            const r = await aspect.extract(p) as FP<FileMatchData>;
+            const r = await aspect.extract(p, undefined) as FP<FileMatchData>;
             assert.strictEqual(r.data.matches.length, 1);
             assert.strictEqual(r.data.matches[0].matchValue, "25");
         });
@@ -119,7 +119,7 @@ describe("fileMatchAspect", () => {
                 grammar,
                 path: "targetFramework",
             });
-            const r = await aspect.extract(p) as FP<FileMatchData>;
+            const r = await aspect.extract(p, undefined) as FP<FileMatchData>;
             assert.strictEqual(r.data.matches.length, 1);
             assert.strictEqual(r.data.matches[0].matchValue, "netcoreapp2.2");
         });

--- a/test/aspect/license.test.ts
+++ b/test/aspect/license.test.ts
@@ -23,21 +23,21 @@ describe("license aspect", () => {
 
     it("should find no license", async () => {
         const p = InMemoryProject.of();
-        const fp: any = await License.extract(p);
+        const fp: any = await License.extract(p, undefined);
         assert(!!fp.data);
         assert.deepStrictEqual(fp.data, { classification: "None", content: undefined, path: undefined });
     });
 
     it("should find Apache license at LICENSE", async () => {
         const p = InMemoryProject.of({ path: "LICENSE", content: asl });
-        const fp: any = await License.extract(p);
+        const fp: any = await License.extract(p, undefined);
         assert(!!fp.data);
         assert.deepStrictEqual(fp.data, { classification: "Apache License", content: asl, path: "LICENSE" });
     });
 
     it("should find Apache license at license.txt", async () => {
         const p = InMemoryProject.of({ path: "license.txt", content: asl });
-        const fp: any = await License.extract(p);
+        const fp: any = await License.extract(p, undefined);
         assert(!!fp.data);
         assert.deepStrictEqual(fp.data, { classification: "Apache License", content: asl, path: "license.txt" });
     });

--- a/test/atomist.config.ts
+++ b/test/atomist.config.ts
@@ -37,7 +37,11 @@ import {
     NpmDeps,
     VirtualProjectFinder,
 } from "@atomist/sdm-pack-fingerprints";
-import { IsNode, nodeBuilder, npmBuilderOptionsFromFile } from "@atomist/sdm-pack-node";
+import {
+    IsNode,
+    nodeBuilder,
+    npmBuilderOptionsFromFile,
+} from "@atomist/sdm-pack-node";
 import {
     PowerShellLanguage,
     ShellLanguage,

--- a/test/atomist.config.ts
+++ b/test/atomist.config.ts
@@ -16,7 +16,10 @@
 
 import { Configuration } from "@atomist/automation-client";
 import { loadUserConfiguration } from "@atomist/automation-client/lib/configuration";
-import { onAnyPush, PushImpact } from "@atomist/sdm";
+import {
+    onAnyPush,
+    PushImpact,
+} from "@atomist/sdm";
 import {
     AllGoals,
     configure,

--- a/test/atomist.config.ts
+++ b/test/atomist.config.ts
@@ -40,7 +40,11 @@ import {
     ShellLanguage,
     YamlLanguage,
 } from "@atomist/sdm-pack-sloc/lib/languages";
-import { mavenBuilder, MavenDefaultOptions, MavenPerBranchDeployment } from "@atomist/sdm-pack-spring";
+import {
+    mavenBuilder,
+    MavenDefaultOptions,
+    MavenPerBranchDeployment,
+} from "@atomist/sdm-pack-spring";
 import * as _ from "lodash";
 import {
     CombinationTagger,
@@ -67,7 +71,8 @@ import { branchCount } from "../lib/aspect/git/branchCount";
 import { GitRecency } from "../lib/aspect/git/gitActivity";
 import { ExposedSecrets } from "../lib/aspect/secret/exposedSecrets";
 import {
-    aspectSupport, AspectSupportOptions,
+    aspectSupport,
+    AspectSupportOptions,
     DefaultVirtualProjectFinder,
 } from "../lib/machine/aspectSupport";
 import * as commonScorers from "../lib/scorer/commonScorers";

--- a/test/atomist.config.ts
+++ b/test/atomist.config.ts
@@ -16,30 +16,62 @@
 
 import { Configuration } from "@atomist/automation-client";
 import { loadUserConfiguration } from "@atomist/automation-client/lib/configuration";
-import { PushImpact, whenPushSatisfies } from "@atomist/sdm";
+import {
+    PushImpact,
+    whenPushSatisfies,
+} from "@atomist/sdm";
 import { configure } from "@atomist/sdm-core";
 import { Build } from "@atomist/sdm-pack-build";
 import { LeinDeps } from "@atomist/sdm-pack-clojure/lib/fingerprints/clojure";
-import { DockerfilePath, DockerFrom, DockerPorts } from "@atomist/sdm-pack-docker";
-import { Aspect, NpmDeps, VirtualProjectFinder } from "@atomist/sdm-pack-fingerprints";
-import { PowerShellLanguage, ShellLanguage, YamlLanguage } from "@atomist/sdm-pack-sloc/lib/languages";
-import { IsMaven, mavenBuilder, MavenDefaultOptions } from "@atomist/sdm-pack-spring";
+import {
+    DockerfilePath,
+    DockerFrom,
+    DockerPorts,
+} from "@atomist/sdm-pack-docker";
+import {
+    Aspect,
+    NpmDeps,
+    VirtualProjectFinder,
+} from "@atomist/sdm-pack-fingerprints";
+import {
+    PowerShellLanguage,
+    ShellLanguage,
+    YamlLanguage,
+} from "@atomist/sdm-pack-sloc/lib/languages";
+import {
+    IsMaven,
+    mavenBuilder,
+    MavenDefaultOptions,
+} from "@atomist/sdm-pack-spring";
 import * as _ from "lodash";
 import { PostgresProjectAnalysisResultStore } from "../lib/analysis/offline/persist/PostgresProjectAnalysisResultStore";
-import { CombinationTagger, RepositoryScorer, TaggerDefinition } from "../lib/aspect/AspectRegistry";
+import {
+    CombinationTagger,
+    RepositoryScorer,
+    TaggerDefinition,
+} from "../lib/aspect/AspectRegistry";
 import { CodeMetricsAspect } from "../lib/aspect/common/codeMetrics";
 import { CodeOwnership } from "../lib/aspect/common/codeOwnership";
 import { CiAspect } from "../lib/aspect/common/stackAspect";
 import { CodeOfConduct } from "../lib/aspect/community/codeOfConduct";
-import { License, LicensePresence } from "../lib/aspect/community/license";
-import { ChangelogAspect, ContributingAspect } from "../lib/aspect/community/oss";
+import {
+    License,
+    LicensePresence,
+} from "../lib/aspect/community/license";
+import {
+    ChangelogAspect,
+    ContributingAspect,
+} from "../lib/aspect/community/oss";
 import { isFileMatchFingerprint } from "../lib/aspect/compose/fileMatchAspect";
 import { globAspect } from "../lib/aspect/compose/globAspect";
 import { branchCount } from "../lib/aspect/git/branchCount";
 import { GitRecency } from "../lib/aspect/git/gitActivity";
 import { AcceptEverythingUndesirableUsageChecker } from "../lib/aspect/ProblemStore";
 import { ExposedSecrets } from "../lib/aspect/secret/exposedSecrets";
-import { aspectSupport, DefaultVirtualProjectFinder } from "../lib/machine/aspectSupport";
+import {
+    aspectSupport,
+    DefaultVirtualProjectFinder,
+} from "../lib/machine/aspectSupport";
 import { sdmConfigClientFactory } from "../lib/machine/machine";
 import * as commonScorers from "../lib/scorer/commonScorers";
 import * as commonTaggers from "../lib/tagger/commonTaggers";

--- a/test/atomist.config.ts
+++ b/test/atomist.config.ts
@@ -20,7 +20,9 @@ import { AcceptEverythingUndesirableUsageChecker } from "../lib/aspect/ProblemSt
 process.env.ATOMIST_MODE = "local";
 
 import { Configuration } from "@atomist/automation-client";
+import { PushImpact } from "@atomist/sdm";
 import { configure } from "@atomist/sdm-core";
+import { Build } from "@atomist/sdm-pack-build";
 import { LeinDeps } from "@atomist/sdm-pack-clojure/lib/fingerprints/clojure";
 import {
     DockerfilePath,
@@ -38,6 +40,7 @@ import {
     ShellLanguage,
     YamlLanguage,
 } from "@atomist/sdm-pack-sloc/lib/languages";
+import { mavenBuilder, MavenDefaultOptions, MavenPerBranchDeployment } from "@atomist/sdm-pack-spring";
 import * as _ from "lodash";
 import {
     CombinationTagger,
@@ -69,11 +72,8 @@ import {
 } from "../lib/machine/aspectSupport";
 import * as commonScorers from "../lib/scorer/commonScorers";
 import * as commonTaggers from "../lib/tagger/commonTaggers";
-import { mavenBuilder, MavenDefaultOptions, MavenPerBranchDeployment } from "@atomist/sdm-pack-spring";
-import { Build } from "@atomist/sdm-pack-build";
 import { buildTimeAspect } from "./aspect/delivery/BuildAspect";
 import { DeliveryGoals } from "./aspect/delivery/DeliveryAspect";
-import { PushImpact } from "@atomist/sdm";
 
 const virtualProjectFinder: VirtualProjectFinder = DefaultVirtualProjectFinder;
 

--- a/test/atomist.config.ts
+++ b/test/atomist.config.ts
@@ -139,7 +139,6 @@ export const configuration: Configuration = configure<TestGoals>(async sdm => {
 
     return {
         fingerprint: {
-            test: onAnyPush(),
             goals: goals.pushImpact,
         },
         build: {

--- a/test/atomist.config.ts
+++ b/test/atomist.config.ts
@@ -76,6 +76,7 @@ import * as commonScorers from "../lib/scorer/commonScorers";
 import * as commonTaggers from "../lib/tagger/commonTaggers";
 import { buildTimeAspect } from "./aspect/delivery/BuildAspect";
 import { storeFingerprints } from "./aspect/delivery/storeFingerprintsPublisher";
+import { onAnyPush, PushImpact } from "@atomist/sdm";
 
 // Ensure we start up in local mode
 process.env.ATOMIST_MODE = "local";
@@ -102,8 +103,14 @@ export const configuration: Configuration = configure<TestGoals>(async sdm => {
                 builder: mavenBuilder(),
             });
 
+        const pushImpact = new PushImpact();
+
         return {
+            // This illustrates a delivery goal
             build,
+
+            // This illustrates pushImpact
+            pushImpact,
         };
     }, []);
 
@@ -128,6 +135,10 @@ export const configuration: Configuration = configure<TestGoals>(async sdm => {
     );
 
     return {
+        fingerprint: {
+            test: onAnyPush(),
+            goals: goals.pushImpact,
+        },
         build: {
             test: IsMaven,
             goals: goals.build,

--- a/test/atomist.config.ts
+++ b/test/atomist.config.ts
@@ -16,6 +16,7 @@
 
 import { Configuration } from "@atomist/automation-client";
 import { loadUserConfiguration } from "@atomist/automation-client/lib/configuration";
+import { onAnyPush, PushImpact } from "@atomist/sdm";
 import {
     AllGoals,
     configure,
@@ -76,7 +77,6 @@ import * as commonScorers from "../lib/scorer/commonScorers";
 import * as commonTaggers from "../lib/tagger/commonTaggers";
 import { buildTimeAspect } from "./aspect/delivery/BuildAspect";
 import { storeFingerprints } from "./aspect/delivery/storeFingerprintsPublisher";
-import { onAnyPush, PushImpact } from "@atomist/sdm";
 
 // Ensure we start up in local mode
 process.env.ATOMIST_MODE = "local";

--- a/test/atomist.config.ts
+++ b/test/atomist.config.ts
@@ -14,36 +14,36 @@
  * limitations under the License.
  */
 
-import { AcceptEverythingUndesirableUsageChecker } from "../lib/aspect/ProblemStore";
 import { Configuration } from "@atomist/automation-client";
+import { loadUserConfiguration } from "@atomist/automation-client/lib/configuration";
 import { PushImpact, whenPushSatisfies } from "@atomist/sdm";
 import { configure } from "@atomist/sdm-core";
 import { Build } from "@atomist/sdm-pack-build";
 import { LeinDeps } from "@atomist/sdm-pack-clojure/lib/fingerprints/clojure";
-import { DockerfilePath, DockerFrom, DockerPorts, } from "@atomist/sdm-pack-docker";
-import { Aspect, NpmDeps, VirtualProjectFinder, } from "@atomist/sdm-pack-fingerprints";
-import { PowerShellLanguage, ShellLanguage, YamlLanguage, } from "@atomist/sdm-pack-sloc/lib/languages";
-import { IsMaven, mavenBuilder, MavenDefaultOptions, } from "@atomist/sdm-pack-spring";
+import { DockerfilePath, DockerFrom, DockerPorts } from "@atomist/sdm-pack-docker";
+import { Aspect, NpmDeps, VirtualProjectFinder } from "@atomist/sdm-pack-fingerprints";
+import { PowerShellLanguage, ShellLanguage, YamlLanguage } from "@atomist/sdm-pack-sloc/lib/languages";
+import { IsMaven, mavenBuilder, MavenDefaultOptions } from "@atomist/sdm-pack-spring";
 import * as _ from "lodash";
-import { CombinationTagger, RepositoryScorer, TaggerDefinition, } from "../lib/aspect/AspectRegistry";
+import { PostgresProjectAnalysisResultStore } from "../lib/analysis/offline/persist/PostgresProjectAnalysisResultStore";
+import { CombinationTagger, RepositoryScorer, TaggerDefinition } from "../lib/aspect/AspectRegistry";
 import { CodeMetricsAspect } from "../lib/aspect/common/codeMetrics";
 import { CodeOwnership } from "../lib/aspect/common/codeOwnership";
 import { CiAspect } from "../lib/aspect/common/stackAspect";
-import { CodeOfConduct, } from "../lib/aspect/community/codeOfConduct";
-import { License, LicensePresence, } from "../lib/aspect/community/license";
-import { ChangelogAspect, ContributingAspect, } from "../lib/aspect/community/oss";
+import { CodeOfConduct } from "../lib/aspect/community/codeOfConduct";
+import { License, LicensePresence } from "../lib/aspect/community/license";
+import { ChangelogAspect, ContributingAspect } from "../lib/aspect/community/oss";
 import { isFileMatchFingerprint } from "../lib/aspect/compose/fileMatchAspect";
 import { globAspect } from "../lib/aspect/compose/globAspect";
 import { branchCount } from "../lib/aspect/git/branchCount";
 import { GitRecency } from "../lib/aspect/git/gitActivity";
+import { AcceptEverythingUndesirableUsageChecker } from "../lib/aspect/ProblemStore";
 import { ExposedSecrets } from "../lib/aspect/secret/exposedSecrets";
-import { aspectSupport, DefaultVirtualProjectFinder, } from "../lib/machine/aspectSupport";
+import { aspectSupport, DefaultVirtualProjectFinder } from "../lib/machine/aspectSupport";
+import { sdmConfigClientFactory } from "../lib/machine/machine";
 import * as commonScorers from "../lib/scorer/commonScorers";
 import * as commonTaggers from "../lib/tagger/commonTaggers";
 import { buildTimeAspect } from "./aspect/delivery/BuildAspect";
-import { sdmConfigClientFactory } from "../lib/machine/machine";
-import { loadUserConfiguration } from "@atomist/automation-client/lib/configuration";
-import { PostgresProjectAnalysisResultStore } from "../lib/analysis/offline/persist/PostgresProjectAnalysisResultStore";
 import { storeFingerprints } from "./aspect/delivery/storeFingerprintsPublisher";
 
 // Ensure we start up in local mode

--- a/test/atomist.config.ts
+++ b/test/atomist.config.ts
@@ -37,6 +37,7 @@ import {
     NpmDeps,
     VirtualProjectFinder,
 } from "@atomist/sdm-pack-fingerprints";
+import { IsNode, nodeBuilder, npmBuilderOptionsFromFile } from "@atomist/sdm-pack-node";
 import {
     PowerShellLanguage,
     ShellLanguage,
@@ -81,7 +82,6 @@ import * as commonScorers from "../lib/scorer/commonScorers";
 import * as commonTaggers from "../lib/tagger/commonTaggers";
 import { buildTimeAspect } from "./aspect/delivery/BuildAspect";
 import { storeFingerprints } from "./aspect/delivery/storeFingerprintsPublisher";
-import { IsNode, nodeBuilder, npmBuilderOptionsFromFile } from "@atomist/sdm-pack-node";
 
 // Ensure we start up in local mode
 process.env.ATOMIST_MODE = "local";

--- a/test/atomist.config.ts
+++ b/test/atomist.config.ts
@@ -15,70 +15,39 @@
  */
 
 import { AcceptEverythingUndesirableUsageChecker } from "../lib/aspect/ProblemStore";
-
-// Ensure we start up in local mode
-process.env.ATOMIST_MODE = "local";
-
 import { Configuration } from "@atomist/automation-client";
-import { PushImpact } from "@atomist/sdm";
+import { PushImpact, whenPushSatisfies } from "@atomist/sdm";
 import { configure } from "@atomist/sdm-core";
 import { Build } from "@atomist/sdm-pack-build";
 import { LeinDeps } from "@atomist/sdm-pack-clojure/lib/fingerprints/clojure";
-import {
-    DockerfilePath,
-    DockerFrom,
-    DockerPorts,
-} from "@atomist/sdm-pack-docker";
-import {
-    Aspect,
-    makeVirtualProjectAware,
-    NpmDeps,
-    VirtualProjectFinder,
-} from "@atomist/sdm-pack-fingerprints";
-import {
-    PowerShellLanguage,
-    ShellLanguage,
-    YamlLanguage,
-} from "@atomist/sdm-pack-sloc/lib/languages";
-import {
-    mavenBuilder,
-    MavenDefaultOptions,
-    MavenPerBranchDeployment,
-} from "@atomist/sdm-pack-spring";
+import { DockerfilePath, DockerFrom, DockerPorts, } from "@atomist/sdm-pack-docker";
+import { Aspect, NpmDeps, VirtualProjectFinder, } from "@atomist/sdm-pack-fingerprints";
+import { PowerShellLanguage, ShellLanguage, YamlLanguage, } from "@atomist/sdm-pack-sloc/lib/languages";
+import { IsMaven, mavenBuilder, MavenDefaultOptions, } from "@atomist/sdm-pack-spring";
 import * as _ from "lodash";
-import {
-    CombinationTagger,
-    RepositoryScorer,
-    TaggerDefinition,
-} from "../lib/aspect/AspectRegistry";
+import { CombinationTagger, RepositoryScorer, TaggerDefinition, } from "../lib/aspect/AspectRegistry";
 import { CodeMetricsAspect } from "../lib/aspect/common/codeMetrics";
 import { CodeOwnership } from "../lib/aspect/common/codeOwnership";
 import { CiAspect } from "../lib/aspect/common/stackAspect";
-import {
-    CodeOfConduct,
-} from "../lib/aspect/community/codeOfConduct";
-import {
-    License,
-    LicensePresence,
-} from "../lib/aspect/community/license";
-import {
-    ChangelogAspect,
-    ContributingAspect,
-} from "../lib/aspect/community/oss";
+import { CodeOfConduct, } from "../lib/aspect/community/codeOfConduct";
+import { License, LicensePresence, } from "../lib/aspect/community/license";
+import { ChangelogAspect, ContributingAspect, } from "../lib/aspect/community/oss";
 import { isFileMatchFingerprint } from "../lib/aspect/compose/fileMatchAspect";
 import { globAspect } from "../lib/aspect/compose/globAspect";
 import { branchCount } from "../lib/aspect/git/branchCount";
 import { GitRecency } from "../lib/aspect/git/gitActivity";
 import { ExposedSecrets } from "../lib/aspect/secret/exposedSecrets";
-import {
-    aspectSupport,
-    AspectSupportOptions,
-    DefaultVirtualProjectFinder,
-} from "../lib/machine/aspectSupport";
+import { aspectSupport, DefaultVirtualProjectFinder, } from "../lib/machine/aspectSupport";
 import * as commonScorers from "../lib/scorer/commonScorers";
 import * as commonTaggers from "../lib/tagger/commonTaggers";
 import { buildTimeAspect } from "./aspect/delivery/BuildAspect";
-import { DeliveryGoals } from "./aspect/delivery/DeliveryAspect";
+import { sdmConfigClientFactory } from "../lib/machine/machine";
+import { loadUserConfiguration } from "@atomist/automation-client/lib/configuration";
+import { PostgresProjectAnalysisResultStore } from "../lib/analysis/offline/persist/PostgresProjectAnalysisResultStore";
+import { storeFingerprints } from "./aspect/delivery/storeFingerprintsPublisher";
+
+// Ensure we start up in local mode
+process.env.ATOMIST_MODE = "local";
 
 const virtualProjectFinder: VirtualProjectFinder = DefaultVirtualProjectFinder;
 
@@ -88,6 +57,8 @@ const build: Build = new Build()
         builder: mavenBuilder(),
     });
 
+const store = new PostgresProjectAnalysisResultStore(sdmConfigClientFactory(loadUserConfiguration()));
+
 /**
  * Sample configuration to enable testing
  * @type {Configuration}
@@ -95,7 +66,7 @@ const build: Build = new Build()
 export const configuration: Configuration = configure(async sdm => {
     sdm.addExtensionPacks(
         aspectSupport({
-            aspects: aspects({ build }),
+            aspects: aspects(),
 
             pushImpactGoal: new PushImpact(),
             build,
@@ -108,13 +79,19 @@ export const configuration: Configuration = configure(async sdm => {
             // Customize this to respond to undesirable usages
             undesirableUsageChecker: AcceptEverythingUndesirableUsageChecker,
 
+            publishFingerprints: storeFingerprints(store),
+
             virtualProjectFinder,
         }),
     );
 
+    sdm.withPushRules(
+        whenPushSatisfies(IsMaven).setGoals(build),
+    );
+
 });
 
-function aspects(opts: DeliveryGoals): Aspect[] {
+function aspects(): Aspect[] {
     return [
         DockerFrom,
         DockerfilePath,
@@ -145,11 +122,8 @@ function aspects(opts: DeliveryGoals): Aspect[] {
         // allMavenDependenciesAspect,    // This is expensive
         LeinDeps,
 
-        buildTimeAspect({
-            ...opts,
-            publisher: async fps => null,
-        }),
-    ].map(aspect => makeVirtualProjectAware(aspect, virtualProjectFinder));
+        buildTimeAspect(),
+    ];
 }
 
 export function scorers(): RepositoryScorer[] {

--- a/test/spider/github/GithubSpider.test.ts
+++ b/test/spider/github/GithubSpider.test.ts
@@ -22,6 +22,7 @@ import { TmpDirectoryManager } from "@atomist/automation-client/lib/spi/clone/tm
 import { FP } from "@atomist/sdm-pack-fingerprints";
 import * as assert from "assert";
 import {
+    FingerprintInsertionResult,
     FingerprintKind,
     FingerprintUsage,
     PersistResult,
@@ -76,6 +77,10 @@ class FakeProjectAnalysisResultStore implements ProjectAnalysisResultStore {
 
     public fingerprintsToReposTree(): Promise<PlantedTree> {
         throw new Error("Method not implemented");
+    }
+
+    public persistAdditionalFingerprints(): Promise<FingerprintInsertionResult> {
+        return undefined;
     }
 
     public aspectDriftTree(workspaceId: string, threshold: number, type?: string): Promise<PlantedTree> {


### PR DESCRIPTION
Adds delivery aspect concept. It's now possible to pull fingerprints from goal execution.

Also includes several fixes:

- Updating fingerprint pack with new signature of `Aspect.extract`
- Fixing SQL statement in fingerprint of kind query
- Fixing type guard for `ProjectAnalysisResult`

Backward compatible.
Depends on https://github.com/atomist/sdm-pack-fingerprints/pull/134  