### PR TITLE
Fewer scored aspects

### DIFF
--- a/lib/aspect/score/ScoredAspect.ts
+++ b/lib/aspect/score/ScoredAspect.ts
@@ -179,19 +179,25 @@ export function emitScoringAspects(name: string,
                                    scoreWeightings: ScoreWeightings): ScoredAspect[] {
     const fScorers = scorers.filter(isRepositoryScorer);
     const pScorers = scorers.filter(s => !isRepositoryScorer(s)) as any;
-    const psa = pushScoringAspect(
-        {
-            name: name + "_push",
-            displayName: name,
-            scorers: pScorers,
-            scoreWeightings,
-        });
-    const fsa = fingerprintScoringAspect(
-        {
-            name,
-            displayName: name,
-            scorers: fScorers,
-            scoreWeightings,
-        });
-    return [fsa, psa];
+    const pushScoreSuffix = fScorers.length > 0 && pScorers.length > 0 ? "_push" : "";
+    const result: ScoredAspect[] = [];
+    if (pScorers.length > 0) {
+        result.push(pushScoringAspect(
+            {
+                name: name + pushScoreSuffix,
+                displayName: name,
+                scorers: pScorers,
+                scoreWeightings,
+            }));
+    }
+    if (fScorers.length > 0) {
+        result.push(fingerprintScoringAspect(
+            {
+                name,
+                displayName: name,
+                scorers: fScorers,
+                scoreWeightings,
+            }));
+    }
+    return result;
 }

--- a/lib/aspect/score/ScoredAspect.ts
+++ b/lib/aspect/score/ScoredAspect.ts
@@ -174,7 +174,9 @@ export async function pushScoresFor(pushScorers: Array<PushScorer | ProjectScore
     return scores;
 }
 
-export function emitScoringAspects(name: string, scorers: AspectCompatibleScorer[], scoreWeightings: ScoreWeightings): ScoredAspect[] {
+export function emitScoringAspects(name: string,
+                                   scorers: AspectCompatibleScorer[],
+                                   scoreWeightings: ScoreWeightings): ScoredAspect[] {
     const fScorers = scorers.filter(isRepositoryScorer);
     const pScorers = scorers.filter(s => !isRepositoryScorer(s)) as any;
     const psa = pushScoringAspect(
@@ -182,12 +184,14 @@ export function emitScoringAspects(name: string, scorers: AspectCompatibleScorer
             name: name + "_push",
             displayName: name,
             scorers: pScorers,
+            scoreWeightings,
         });
     const fsa = fingerprintScoringAspect(
         {
             name,
             displayName: name,
             scorers: fScorers,
+            scoreWeightings,
         });
     return [fsa, psa];
 }


### PR DESCRIPTION
Only create the aspects we have scorers for.
And only use the distinguishing suffix when we have both

And pass down the weightings.