### PR TITLE
Count visible aspects

### DIFF
--- a/lib/analysis/offline/spider/SpiderAnalyzer.ts
+++ b/lib/analysis/offline/spider/SpiderAnalyzer.ts
@@ -100,7 +100,8 @@ async function runConsolidates(p: Project,
                                fingerprints: FP[],
                                repoTracking: RepoBeingTracked): Promise<void> {
     for (const aspect of aspects) {
-        const consolidatedFingerprints = await safeConsolidate(aspect, fingerprints, p, pili, repoTracking.plan(aspect, "consolidate"));
+        const consolidatedFingerprints = await safeConsolidate(aspect, fingerprints, p, pili,
+            repoTracking.plan(aspect, "consolidate"));
         fingerprints.push(...consolidatedFingerprints);
     }
 }

--- a/lib/analysis/tracking/analysisTracker.ts
+++ b/lib/analysis/tracking/analysisTracker.ts
@@ -68,6 +68,7 @@ type WayToGetFingerprintsFromAnAspect = "extract" | "consolidate";
 
 export interface AspectForReporting {
     aspectName: string;
+    visible: boolean;
     stage: WayToGetFingerprintsFromAnAspect;
     millisTaken?: number;
     error?: Error;
@@ -83,7 +84,11 @@ export class AspectBeingTracked {
     public fingerprintsFound: number | undefined;
     public failedWith: Error | undefined;
     public moreFailures: Array<{ error: Error, furtherDescription: string }> = [];
-    constructor(readonly params: { aspectName: string, aboutToRun: WayToGetFingerprintsFromAnAspect }) {
+    constructor(readonly params: {
+        aspectName: string,
+        visible: boolean,
+        aboutToRun: WayToGetFingerprintsFromAnAspect,
+    }) {
         this.startedAt = new Date();
     }
 
@@ -116,6 +121,7 @@ export class AspectBeingTracked {
         }
         return {
             aspectName: this.params.aspectName,
+            visible: this.params.visible,
             stage: this.params.aboutToRun,
             millisTaken: this.completedAt ? this.completedAt.getTime() - this.startedAt.getTime() : undefined,
             fingerprintsFound: this.fingerprintsFound || 0,
@@ -126,6 +132,7 @@ export class AspectBeingTracked {
 
 export interface AnalysisTrackingAspect {
     name: string;
+    displayName: string | undefined;
 }
 
 export class RepoBeingTracked {
@@ -162,7 +169,11 @@ export class RepoBeingTracked {
     }
 
     public plan(aspect: AnalysisTrackingAspect, aboutToRun: WayToGetFingerprintsFromAnAspect): AspectBeingTracked {
-        const newAspect = new AspectBeingTracked({ aspectName: aspect.name, aboutToRun });
+        const newAspect = new AspectBeingTracked({
+            aspectName: aspect.name,
+            visible: !!aspect.displayName, // this determines whether the aspect will display on the Insights page
+            aboutToRun,
+        });
         this.aspects.push(newAspect);
         return newAspect;
     }

--- a/lib/scorer/commonWorkspaceScorers.ts
+++ b/lib/scorer/commonWorkspaceScorers.ts
@@ -23,7 +23,7 @@ const average = array => array.reduce((a, b) => a + b) / array.length;
 
 /**
  * Use the average repo score as the score
- **/
+ */
 export const AverageRepoScore: WorkspaceScorer = {
     name: "average",
     description: "Average score for repositories",

--- a/test/page/sunburstPage.test.ts
+++ b/test/page/sunburstPage.test.ts
@@ -24,7 +24,7 @@ describe("buttons to change the selected tags in the explore view of sunburst", 
 
     it("doesn't barf when the tree is not provided", () => {
         const subject = new TagGroup(["node", "!dead"], undefined);
-        subject.allTagNames;
+        assert.deepStrictEqual(subject.allTagNames, ["node", "dead"]);
     });
 
     it("lists the names of all the tags", () => {

--- a/views/analysisTrackingPage.tsx
+++ b/views/analysisTrackingPage.tsx
@@ -15,6 +15,7 @@ interface AnalysisTrackingRepo {
 interface AnalysisTrackingAspect {
     aspectName: string;
     fingerprintsFound: number;
+    visible: boolean;
     error?: Error;
 }
 interface AnalysisTrackingAnalysis {
@@ -56,8 +57,9 @@ function summarizeAspects(aspects: AnalysisTrackingAspect[]): React.ReactElement
     const fingerprintTotal = aspects.map(a => a.fingerprintsFound).filter(f => !!f).reduce((a, b) => a + b, 0);
     const errors = aspects.filter(a => !!a.error);
     const errorDisplays = errors.length > 0 ? <div>{errors.map(displayAspectError)}</div> : undefined;
+    const reportVisibleAspects = `(in ${aspects.filter(a => a.fingerprintsFound > 0 && a.visible).length} visible aspects)`;
     return <div>
-        {aspects.length} aspects => {fingerprintTotal} fingerprints
+        {aspects.length} aspects => {fingerprintTotal} fingerprints {reportVisibleAspects}
         {errorDisplays}
     </div>;
 }
@@ -136,7 +138,7 @@ export function AnalysisTrackingPage(props: AnalysisTrackingProps): React.ReactE
     }
     return <div>
         <h2>Refresh this page to see progress.</h2>
-        <a href="aspects">Track aspect performance</a>
+        <a href="aspects/">Track aspect performance</a>
         {listAnalyses(props.analyses)}
     </div>;
 }

--- a/views/analysisTrackingPage.tsx
+++ b/views/analysisTrackingPage.tsx
@@ -136,6 +136,7 @@ export function AnalysisTrackingPage(props: AnalysisTrackingProps): React.ReactE
     }
     return <div>
         <h2>Refresh this page to see progress.</h2>
+        <a href="aspects">Track aspect performance</a>
         {listAnalyses(props.analyses)}
     </div>;
 }


### PR DESCRIPTION
 This makes for less confusion when you click on the Insights page and don't see the full number.
    In my testing it was still off by one compared to the aspects on the Insights page though.
    Digging into that is a different task
<img width="705" alt="Screen Shot 2019-09-19 at 11 21 38 AM" src="https://user-images.githubusercontent.com/1149737/65270307-81fece00-dae0-11e9-8460-d2721dd65064.png">
